### PR TITLE
Add Claude Code getting started guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,54 @@
 - <b>All contributors are constantly investigating clever workarounds that allow us to utilize the full potential of ChatGPT. Yes, this includes making ChatGPT improve its own jailbreak prompts.
 ---
 
+## Getting Started with Claude Code
+
+[Claude Code](https://claude.ai/code) is Anthropic's official CLI for Claude that helps with software engineering tasks directly from your terminal.
+
+### Installation
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+### Add to PATH (if not already done)
+
+After installation, if `claude` is not found in your shell, add `~/.local/bin` to your PATH:
+
+**For zsh (macOS default):**
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+```
+
+**For bash:**
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
+```
+
+### First-time Login
+
+```bash
+claude
+```
+
+On first run, Claude Code will prompt you to log in with your Anthropic account. Follow the on-screen instructions to authenticate.
+
+### Usage
+
+Navigate to your project directory, then launch Claude Code:
+
+```bash
+cd /path/to/your/actual/project   # replace with your real project path
+claude
+```
+
+For help:
+```bash
+claude --help
+```
+
+---
+
 - <https://chat.openai.com/>
 <!--
 - [Is ChatGPT "DAN" Real? Gonna find out [Part 1]](https://www.youtube.com/watch?v=-q8woRG9FrI) \


### PR DESCRIPTION
## Summary
Added a comprehensive "Getting Started with Claude Code" section to the README to help users install and use Anthropic's Claude CLI tool.

## Changes
- Added installation instructions using the official install script
- Included PATH configuration steps for both zsh (macOS) and bash shells
- Documented first-time login and authentication flow
- Provided basic usage examples showing how to launch Claude Code in a project directory
- Added reference to the `--help` command for additional documentation

## Details
The new section is positioned prominently near the top of the README (after the introduction) to guide new users through the setup process. Instructions cover:
- One-line installation via curl
- Shell-specific PATH configuration for both macOS and Linux users
- Initial authentication workflow
- Basic usage patterns
- Help command reference

https://claude.ai/code/session_019rWi4aKS8mfWa5HTU4kFj5